### PR TITLE
Transparency Support

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/camera.py
+++ b/custom_components/xiaomi_cloud_map_extractor/camera.py
@@ -107,6 +107,7 @@ class VacuumCamera(Camera):
                  drawables, sizes, texts, attributes):
         super().__init__()
         self.hass = hass
+        self.content_type = "image/png"
         self._vacuum = miio.Vacuum(host, token)
         self._connector = XiaomiCloudConnector(username, password, country)
         self._name = name

--- a/custom_components/xiaomi_cloud_map_extractor/image_handler.py
+++ b/custom_components/xiaomi_cloud_map_extractor/image_handler.py
@@ -58,7 +58,7 @@ class ImageHandler:
         trim_bottom = int(image_config[CONF_TRIM][CONF_BOTTOM] * height / 100)
         trimmed_height = height - trim_top - trim_bottom
         trimmed_width = width - trim_left - trim_right
-        image = Image.new('RGB', (trimmed_width, trimmed_height))
+        image = Image.new('RGBA', (trimmed_width, trimmed_height))
         pixels = image.load()
         for img_y in range(trimmed_height):
             for img_x in range(trimmed_width):

--- a/custom_components/xiaomi_cloud_map_extractor/image_handler.py
+++ b/custom_components/xiaomi_cloud_map_extractor/image_handler.py
@@ -119,9 +119,12 @@ class ImageHandler:
 
     @staticmethod
     def draw_no_go_areas(image, areas, colors):
+        base_image = image.data
+        image.data = Image.new('RGBA', image.data.size)
         ImageHandler.__draw_areas__(image, areas,
                                     ImageHandler.__get_color__(COLOR_NO_GO_ZONES, colors),
                                     ImageHandler.__get_color__(COLOR_NO_GO_ZONES_OUTLINE, colors))
+        image.data = Image.alpha_composite(base_image, image.data)
 
     @staticmethod
     def draw_no_mopping_areas(image, areas, colors):


### PR DESCRIPTION
#8 Camera allows specifying a content type, by default its set to image/jpeg. Chrome recognized that image is a png event if content type is set incorrectly, but better to keep it in sync.

Sets camera content_type to image/png
Sets base image mode to RGBA