### PR TITLE
Updated supported device list

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ This integration was tested on following vacuums:
  - Roborock S5 Max
  - Roborock S6
  - Roborock S6 MaxV
+ - Roborock S6 Pure
  
 ## Unsupported devices
 


### PR DESCRIPTION
Checked on my Roborock S6 Pure (model: roborock.vacuum.a08, firmware: 3.5.8_0938). Successfully obtained room numbers and rooms.