### PR TITLE
Refactoring the cloud connector to support map downloading with the new API

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/camera.py
+++ b/custom_components/xiaomi_cloud_map_extractor/camera.py
@@ -222,9 +222,10 @@ class VacuumCamera(Camera):
                 counter = counter - 1
         self._received_map_name_previously = map_name != "retry"
         if self._logged_in and map_name != "retry" and self._country is not None:
-            map_data, map_stored = self._connector.get_map(self._country, map_name, self._colors, self._drawables,
-                                                           self._texts, self._sizes, self._image_config,
-                                                           self._store_map)
+            device = self._connector.get_device(country=self._country, ip_address=self._vacuum.ip, token=self._vacuum.token)
+            map_data, map_stored = device.get_map(map_name, self._colors, self._drawables,
+                                                  self._texts, self._sizes, self._image_config,
+                                                  self._store_map)
             if map_data is not None:
                 # noinspection PyBroadException
                 try:


### PR DESCRIPTION
I have a Viomi V2 Pro vacuum which is a rebranded STYJ02YM model. I've followed the https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues/23 ticket and managed to modify the `XiaomiCloudConnector` to download my map. I know that the map format is different, but I had to download it first.  A journey of a thousand miles begins with a single step :-)

The new API is a little different and requiring more parameters. I didn't want to add even more arguments to `get_map()` / `get_raw_map_data()`, so I separated the device/map management from the connector object.

I modified the Home Assistant camera code, but I was not able to test it without a supported vacuum.