### PR TITLE
V2 map parsing fixes

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/image_handler_v2.py
+++ b/custom_components/xiaomi_cloud_map_extractor/image_handler_v2.py
@@ -11,10 +11,18 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class ImageHandlerV2(ImageHandler):
+    MAP_OUTSIDE = 0x00
+    MAP_WALL = 0xff
+    MAP_SCAN = 0x01
+    MAP_ROOM_MIN = 10
+    MAP_ROOM_MAX = 59
+    MAP_SELECTED_ROOM_MIN = 60
+    MAP_SELECTED_ROOM_MAX = 109
 
     @staticmethod
-    def parse(buf, width, height, colors, image_config) -> Tuple[ImageType, dict]:
+    def parse(buf, width, height, colors, image_config) -> Tuple[ImageType, dict, dict]:
         rooms = {}
+        areas = {}
         scale = image_config[CONF_SCALE]
         trim_left = int(image_config[CONF_TRIM][CONF_LEFT] * width / 100)
         trim_right = int(image_config[CONF_TRIM][CONF_RIGHT] * width / 100)
@@ -34,16 +42,26 @@ class ImageHandlerV2(ImageHandler):
                 pixel_type = buf.get_uint8('pixel')
                 x = img_x
                 y = trimmed_height - 1 - img_y
-                if pixel_type == 0:
+                if pixel_type == ImageHandlerV2.MAP_OUTSIDE:
                     pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_OUTSIDE, colors)
-                elif pixel_type == 255:
-                    pixels[x, y] = ImageHandler.__get_color__(COLOR_GREY_WALL, colors)
-                elif pixel_type == 1:
+                elif pixel_type == ImageHandlerV2.MAP_WALL:
+                    pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_WALL_V2, colors)
+                elif pixel_type == ImageHandlerV2.MAP_SCAN:
                     pixels[x, y] = ImageHandler.__get_color__(COLOR_SCAN, colors)
-                elif 10 <= pixel_type < 60:
-                    room_number = pixel_type
-                    room_x = x
-                    room_y = y
+                elif ImageHandlerV2.MAP_ROOM_MIN <= pixel_type <= ImageHandlerV2.MAP_SELECTED_ROOM_MAX:
+                    room_x = img_x + trim_left
+                    room_y = img_y + trim_bottom
+                    if pixel_type < ImageHandlerV2.MAP_SELECTED_ROOM_MIN:
+                        room_number = pixel_type
+                    else:
+                        room_number = pixel_type - ImageHandlerV2.MAP_SELECTED_ROOM_MIN + ImageHandlerV2.MAP_ROOM_MIN
+                        if room_number not in areas:
+                            areas[room_number] = (room_x, room_y, room_x, room_y)
+                        else:
+                            areas[room_number] = (min(areas[room_number][0], room_x),
+                                                  min(areas[room_number][1], room_y),
+                                                  max(areas[room_number][2], room_x),
+                                                  max(areas[room_number][3], room_y))
                     if room_number not in rooms:
                         rooms[room_number] = (room_x, room_y, room_x, room_y)
                     else:
@@ -51,9 +69,10 @@ class ImageHandlerV2(ImageHandler):
                                               min(rooms[room_number][1], room_y),
                                               max(rooms[room_number][2], room_x),
                                               max(rooms[room_number][3], room_y))
-                    default = ImageHandler.ROOM_COLORS[room_number >> 1]
+                    default = ImageHandler.ROOM_COLORS[room_number % len(ImageHandler.ROOM_COLORS)]
                     pixels[x, y] = ImageHandler.__get_color__(f"{COLOR_ROOM_PREFIX}{room_number}", colors, default)
                 else:
+                    pixels[x, y] = ImageHandler.__get_color__(COLOR_UNKNOWN, colors)
                     u.add(pixel_type)
             buf.skip('trim_right', trim_right)
         buf.skip('trim_top', trim_top * width)
@@ -61,4 +80,4 @@ class ImageHandlerV2(ImageHandler):
             image = image.resize((int(trimmed_width * scale), int(trimmed_height * scale)), resample=Image.NEAREST)
         if len(u) > 0:
             _LOGGER.warning('unknown pixel_types: %s', u)
-        return image, rooms
+        return image, rooms, areas

--- a/custom_components/xiaomi_cloud_map_extractor/map_data_parser_v2.py
+++ b/custom_components/xiaomi_cloud_map_extractor/map_data_parser_v2.py
@@ -221,9 +221,8 @@ class MapDataParserV2(MapDataParser):
         buf.skip('unknown1', 4)
         history_count = buf.get_uint32('history_count')
         for _ in range(history_count):
-            buf.skip('path.unknown1', 1)
+            mode = buf.get_uint8('mode')    # 0: taxi, 1: working
             path_points.append(MapDataParserV2.parse_position(buf, 'path'))
-            # buf.skip('path.unknown2', 9)
         return Path(len(path_points), 1, 0, path_points)
 
     @staticmethod

--- a/custom_components/xiaomi_cloud_map_extractor/map_data_parser_v2.py
+++ b/custom_components/xiaomi_cloud_map_extractor/map_data_parser_v2.py
@@ -91,9 +91,9 @@ class MapDataParserV2(MapDataParser):
     def parse(raw: bytes, colors, drawables, texts, sizes, image_config) -> MapData:
         map_data = MapData()
         buf = ParsingBuffer('header', raw, 0, len(raw))
-        feature_flags = buf.get_uint32('featureFlags')
+        feature_flags = buf.get_uint32('feature_flags')
         map_id = buf.peek_uint32('map_id')
-        _LOGGER.debug('featureFlags: 0x%x, map_id: %d', feature_flags, map_id)
+        _LOGGER.debug('feature_flags: 0x%x, map_id: %d', feature_flags, map_id)
 
         if feature_flags & MapDataParserV2.FEATURE_ROBOT_STATUS != 0:
             MapDataParserV2.parse_section(buf, 'robot_status', map_id)
@@ -151,10 +151,13 @@ class MapDataParserV2(MapDataParser):
             MapDataParserV2.parse_section(buf, 'unknown3', map_id)
             MapDataParserV2.parse_unknown_section(buf)
 
+        _LOGGER.debug('rooms: %s', [str(room) for number, room in map_data.rooms.items()])
         if not map_data.image.is_empty:
             MapDataParserV2.draw_elements(colors, drawables, sizes, map_data, image_config)
             if len(map_data.rooms) > 0 and map_data.vacuum_position is not None:
                 map_data.vacuum_room = MapDataParserV2.get_current_vacuum_room(buf, map_data.vacuum_position)
+                _LOGGER.debug('current vacuum room: %s', map_data.vacuum_room)
+            #ImageHandlerV2.draw_zones(map_data.image, [room for number, room in map_data.rooms.items()], colors)
             ImageHandlerV2.rotate(map_data.image)
             ImageHandlerV2.draw_texts(map_data.image, texts)
         return map_data
@@ -272,7 +275,7 @@ class MapDataParserV2(MapDataParser):
             if map_data_rooms is not None and room_id in map_data_rooms:
                 map_data_rooms[room_id].name = room_name
             buf.skip('room.unknown1', 1)
-            room_text_pos = MapDataParserV2.parse_position(buf, 'xxx')
+            room_text_pos = MapDataParserV2.parse_position(buf, 'room.text_pos')
             _LOGGER.debug('room#%d: %s %s', room_id, room_name, room_text_pos)
         buf.skip('unknown1', 6)
 

--- a/scripts/get_map.py
+++ b/scripts/get_map.py
@@ -31,7 +31,7 @@ colors = {
     "color_path": (255, 0, 0, 127),
     "color_goto_path": (0, 255, 0),
     "color_predicted_path": (0, 0, 255),
-    "color_zones": (0x1F, 0x6A, 0xFC),
+    "color_zones": (0x1F, 0x6A, 0xFC, 128),
     "color_zones_outline": (0x25, 0x74, 0xB5, 0x60),
 }
 


### PR DESCRIPTION
This PR is created on the top of my previous PR.

In the tmp.zip map the `unknown1` section was problematic, the fixed size skip has been replaced to a variable size skip. Checks added to determine whether we managed to parse the whole buffer. The magic checking has been reenabled to avoid silent data corruption.

The `unknown3` section has been replaced by a more proper parsing code. I tested all of these changes on my map and on tmp.zip map too.