### PR TITLE
Add blueprint to control camera state

### DIFF
--- a/blueprints/automation/xiaomi_cloud_map_extractor/disable_vacuum_camera_update_when_docked.yaml
+++ b/blueprints/automation/xiaomi_cloud_map_extractor/disable_vacuum_camera_update_when_docked.yaml
@@ -1,0 +1,30 @@
+blueprint:
+  name: Disable vacuum camera update when docked
+  description: Disable the automatic update of the vacuum camera when the robot is docked.
+  domain: automation
+  source_url: https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/blueprints/automation/xiaomi_cloud_map_extractor/disable_vacuum_camera_update_when_docked.yaml
+  input:
+    vacuum:
+      name: Vacuum device
+      selector:
+        entity:
+          domain: vacuum
+    camera:
+      name: Vacuum camera
+      selector:
+        entity:
+          domain: camera
+
+mode: restart
+
+trigger:
+  platform: state
+  entity_id: !input vacuum
+
+condition:
+  - condition: template
+    value_template: '{{ trigger.to_state.state != trigger.from_state.state }}'
+
+action:
+  - service: '{% if trigger.to_state.state in ("unavailable", "unknown", "docked") %}homeassistant.turn_off{% else %}homeassistant.turn_on{% endif %}'
+    entity_id: !input camera

--- a/blueprints/automation/xiaomi_cloud_map_extractor/disable_vacuum_camera_update_when_docked.yaml
+++ b/blueprints/automation/xiaomi_cloud_map_extractor/disable_vacuum_camera_update_when_docked.yaml
@@ -18,13 +18,18 @@ blueprint:
 mode: restart
 
 trigger:
-  platform: state
-  entity_id: !input vacuum
+  - platform: state
+    entity_id: !input vacuum
 
 condition:
   - condition: template
     value_template: '{{ trigger.to_state.state != trigger.from_state.state }}'
 
 action:
-  - service: '{% if trigger.to_state.state in ("unavailable", "unknown", "docked") %}homeassistant.turn_off{% else %}homeassistant.turn_on{% endif %}'
+  - service: |
+      {% if trigger.to_state.state in ["unavailable", "unknown", "docked"] %}
+        camera.turn_off
+      {% else %}
+        camera.turn_on
+      {% endif %}
     entity_id: !input camera


### PR DESCRIPTION
I was not satisfied by the https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues/77 solution: creating a proper automatization job is not trivial. Here comes this blueprint for rescue :-)

The condition part is important in this blueprint if we don't want to run the update method on every vacuum attribute change (e.g. battery charging).

If you like this, an import blueprint badge could be placed on the main page:
https://community.home-assistant.io/t/about-blueprints/253788