### PR TITLE
Fix blueprint errors caused by manual run (#162)

### DIFF
--- a/blueprints/automation/disable_vacuum_camera_update_when_docked.yaml
+++ b/blueprints/automation/disable_vacuum_camera_update_when_docked.yaml
@@ -26,6 +26,8 @@ condition:
     value_template: '{{ trigger.to_state.state != trigger.from_state.state }}'
 
 action:
+  - condition: trigger
+    id: 0
   - service: |
       {% if trigger.to_state.state in ["unavailable", "unknown", "docked"] %}
         camera.turn_off


### PR DESCRIPTION
It seems the error messages generated when the automation started manually. The `trigger.from_state` and `trigger.to_state` attributes are valid only when invocated by the trigger.

During manual start, the condition won't be evaluated, and the action part will be called without these attributes.