### PR TITLE
feat: add dreame devices support

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/common/map_data.py
+++ b/custom_components/xiaomi_cloud_map_extractor/common/map_data.py
@@ -18,6 +18,9 @@ class Point:
             return f"({self.x}, {self.y})"
         return f"({self.x}, {self.y}, a = {self.a})"
 
+    def __repr__(self):
+        return self.__str__()
+
     def __eq__(self, other):
         return other is not None and self.x == other.x and self.y == other.y and self.a == other.a
 
@@ -161,6 +164,9 @@ class Zone:
     def __str__(self):
         return f"[{self.x0}, {self.y0}, {self.x1}, {self.y1}]"
 
+    def __repr__(self):
+        return self.__str__()
+
     def as_dict(self):
         return {
             ATTR_X0: self.x0,
@@ -194,6 +200,9 @@ class Room(Zone):
     def __str__(self):
         return f"[number: {self.number}, name: {self.name}, {self.x0}, {self.y0}, {self.x1}, {self.y1}]"
 
+    def __repr__(self):
+        return self.__str__()
+
     def point(self) -> Optional[Point]:
         if self.pos_x is not None and self.pos_y is not None and self.name is not None:
             return Point(self.pos_x, self.pos_y)
@@ -208,6 +217,9 @@ class Wall:
 
     def __str__(self):
         return f"[{self.x0}, {self.y0}, {self.x1}, {self.y1}]"
+
+    def __repr__(self):
+        return self.__str__()
 
     def as_dict(self):
         return {
@@ -239,6 +251,9 @@ class Area:
 
     def __str__(self):
         return f"[{self.x0}, {self.y0}, {self.x1}, {self.y1}, {self.x2}, {self.y2}, {self.x3}, {self.y3}]"
+
+    def __repr__(self):
+        return self.__str__()
 
     def as_dict(self):
         return {

--- a/custom_components/xiaomi_cloud_map_extractor/dreame/image_handler.py
+++ b/custom_components/xiaomi_cloud_map_extractor/dreame/image_handler.py
@@ -1,0 +1,70 @@
+import logging
+from enum import IntEnum
+
+from PIL import Image
+from PIL.Image import Image as ImageType
+
+from custom_components.xiaomi_cloud_map_extractor.common.image_handler import ImageHandler
+from custom_components.xiaomi_cloud_map_extractor.const import \
+    CONF_SCALE, CONF_TRIM, CONF_LEFT, CONF_RIGHT, CONF_TOP, CONF_BOTTOM, \
+    COLOR_MAP_OUTSIDE, COLOR_MAP_INSIDE, COLOR_MAP_WALL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ImageHandlerDreame(ImageHandler):
+
+    class PixelTypes(IntEnum):
+        NONE = 0
+        FLOOR = 1
+        WALL = 2
+
+    @staticmethod
+    def parse(raw_data: bytes, header, colors, image_config, map_data_type: str) -> ImageType:
+        scale = image_config[CONF_SCALE]
+        trim_left = int(image_config[CONF_TRIM][CONF_LEFT] * header.image_width / 100)
+        trim_right = int(image_config[CONF_TRIM][CONF_RIGHT] * header.image_width / 100)
+        trim_top = int(image_config[CONF_TRIM][CONF_TOP] * header.image_height / 100)
+        trim_bottom = int(image_config[CONF_TRIM][CONF_BOTTOM] * header.image_height / 100)
+        trimmed_height = header.image_height - trim_top - trim_bottom
+        trimmed_width = header.image_width - trim_left - trim_right
+        image = Image.new('RGBA', (trimmed_width, trimmed_height))
+        if header.image_width == 0 or header.image_height == 0:
+            return ImageHandler.create_empty_map_image(colors)
+        pixels = image.load()
+
+        for i in range(trimmed_height):
+            for j in range(trimmed_width):
+                x = j
+                y = header.image_height - i - 1
+
+                # TODO : use MapDataParserDreame.MapDataTypes enum
+                if map_data_type == "regular":
+                    px = raw_data[(i * header.image_width) + j]
+                    segment_id = px >> 2
+                    if 0 < segment_id < 62:
+                        pass
+                    else:
+                        masked_px = px & 0b00000011
+
+                        if masked_px == ImageHandlerDreame.PixelTypes.NONE:
+                            pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_OUTSIDE, colors)
+                        elif masked_px == ImageHandlerDreame.PixelTypes.FLOOR:
+                            pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_INSIDE, colors)
+                        elif masked_px == ImageHandlerDreame.PixelTypes.WALL:
+                            pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_WALL, colors)
+                        else:
+                            _LOGGER.warning(f'unhandled pixel type: {px}')
+                elif map_data_type == "rism":
+                    px = raw_data[(i * header.image_width) + j]
+                    segment_id = px & 0b01111111
+                    wall_flag = px >> 7
+
+                    if wall_flag:
+                        pixels[x, y] = ImageHandler.__get_color__(COLOR_MAP_WALL, colors)
+                    elif segment_id > 0:
+                        pass
+
+        if image_config["scale"] != 1 and header.image_width != 0 and header.image_height != 0:
+            image = image.resize((int(trimmed_width * scale), int(trimmed_height * scale)), resample=Image.NEAREST)
+        return image

--- a/custom_components/xiaomi_cloud_map_extractor/dreame/map_data_parser.py
+++ b/custom_components/xiaomi_cloud_map_extractor/dreame/map_data_parser.py
@@ -1,0 +1,209 @@
+import base64
+import logging
+import json
+import re
+import zlib
+from enum import IntEnum, Enum
+from typing import Optional, List
+
+from custom_components.xiaomi_cloud_map_extractor.common.map_data import MapData, Point, ImageData, Path, Area
+from custom_components.xiaomi_cloud_map_extractor.common.map_data_parser import MapDataParser
+from custom_components.xiaomi_cloud_map_extractor.dreame.image_handler import ImageHandlerDreame
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MapDataHeader:
+    def __init__(self):
+        self.map_index: Optional[int] = None
+        self.frame_type: Optional[int] = None
+        self.vacuum_position: Optional[Point] = None
+        self.charger_position: Optional[Point] = None
+        self.image_pixel_size: Optional[int] = None
+        self.image_width: Optional[int] = None
+        self.image_height: Optional[int] = None
+        self.image_left: Optional[int] = None
+        self.image_top: Optional[int] = None
+
+
+class MapDataParserDreame(MapDataParser):
+    HEADER_SIZE = 27
+    PATH_REGEX = r'(?P<operator>[SL])(?P<x>-?\d+),(?P<y>-?\d+)'
+
+    class PathOperators(str, Enum):
+        START = "S"
+        RELATIVE_LINE = "L"
+
+    class FrameTypes(IntEnum):
+        I = 73
+        P = 80
+
+    class MapDataTypes(str, Enum):
+        REGULAR = "regular"
+        RISM = "rism"  # Room - information
+
+    @staticmethod
+    def decode_map(raw_map: str, colors, drawables, texts, sizes, image_config,
+                   map_data_type=MapDataTypes.REGULAR) -> MapData:
+        _LOGGER.debug(f'decoding {map_data_type} type map')
+        raw_map_string = raw_map.replace('_', '/').replace('-', '+')
+        unzipped = zlib.decompress(base64.decodebytes(raw_map_string.encode("utf8")))
+        return MapDataParserDreame.parse(unzipped, colors, drawables, texts, sizes, image_config, map_data_type)
+
+    @staticmethod
+    def parse(raw: bytes, colors, drawables, texts, sizes, image_config,
+              map_data_type: MapDataTypes) -> Optional[MapData]:
+        map_data = MapData()
+
+        header = MapDataParserDreame.parse_header(raw)
+
+        if header.frame_type != MapDataParserDreame.FrameTypes.I:
+            _LOGGER.error("unsupported map frame type")
+            return
+
+        if len(raw) >= MapDataParserDreame.HEADER_SIZE + header.image_width * header.image_height:
+            image_raw = raw[
+                MapDataParserDreame.HEADER_SIZE:
+                MapDataParserDreame.HEADER_SIZE + header.image_width * header.image_height
+            ]
+            additional_data_raw = raw[MapDataParserDreame.HEADER_SIZE + header.image_width * header.image_height:]
+            additional_data_json = json.loads(additional_data_raw.decode("utf8"))
+            _LOGGER.debug(f'map additional_data: {additional_data_json}')
+
+            map_data.charger = header.charger_position
+            map_data.vacuum_position = header.vacuum_position
+
+            if additional_data_json.get("rism") and\
+                    additional_data_json.get("ris") and additional_data_json["ris"] == 2:
+                rism_map_data = MapDataParserDreame.decode_map(
+                    additional_data_json["rism"],
+                    colors,
+                    drawables,
+                    texts,
+                    sizes,
+                    image_config,
+                    MapDataParserDreame.MapDataTypes.RISM
+                )
+                map_data.no_go_areas = rism_map_data.no_go_areas
+
+            if additional_data_json.get("tr"):
+                map_data.path = MapDataParserDreame.parse_path(additional_data_json["tr"])
+
+            if additional_data_json.get("vw"):
+                if additional_data_json["vw"].get("rect"):
+                    map_data.no_go_areas = MapDataParserDreame.parse_areas(additional_data_json["vw"]["rect"])
+
+            map_data.image = MapDataParserDreame.parse_image(image_raw, header, colors, image_config, map_data_type)
+
+            if not map_data.image.is_empty:
+                MapDataParserDreame.draw_elements(colors, drawables, sizes, map_data, image_config)
+
+        return map_data
+
+    @staticmethod
+    def parse_header(raw: bytes) -> Optional[MapDataHeader]:
+        header = MapDataHeader()
+
+        if not raw or len(raw) < MapDataParserDreame.HEADER_SIZE:
+            _LOGGER.error("wrong header size for map")
+            return
+
+        header.map_index = MapDataParserDreame.read_int_16_le(raw)
+        header.frame_type = MapDataParserDreame.read_int_8(raw, 4)
+        header.vacuum_position = Point(
+            MapDataParserDreame.read_int_16_le(raw, 5),
+            MapDataParserDreame.read_int_16_le(raw, 7),
+            MapDataParserDreame.read_int_16_le(raw, 9)
+        )
+        header.charger_position = Point(
+            MapDataParserDreame.read_int_16_le(raw, 11),
+            MapDataParserDreame.read_int_16_le(raw, 13),
+            MapDataParserDreame.read_int_16_le(raw, 15)
+        )
+        header.image_pixel_size = MapDataParserDreame.read_int_16_le(raw, 17)
+        header.image_width = MapDataParserDreame.read_int_16_le(raw, 19)
+        header.image_height = MapDataParserDreame.read_int_16_le(raw, 21)
+        header.image_left = round(MapDataParserDreame.read_int_16_le(raw, 23) / header.image_pixel_size)
+        header.image_top = round(MapDataParserDreame.read_int_16_le(raw, 25) / header.image_pixel_size)
+
+        _LOGGER.debug(f'decoded map header : {header.__dict__}')
+
+        return header
+
+    @staticmethod
+    def parse_image(image_raw: bytes, header: MapDataHeader, colors, image_config,
+                    map_data_type: MapDataTypes) -> ImageData:
+
+        image = ImageHandlerDreame.parse(image_raw, header, colors, image_config, map_data_type)
+
+        return ImageData(
+            header.image_width * header.image_height,
+            header.image_top,
+            header.image_left,
+            header.image_height,
+            header.image_width,
+            image_config,
+            image,
+            lambda p: MapDataParserDreame.map_to_image(p, header.image_pixel_size)
+        )
+
+    @staticmethod
+    def map_to_image(p: Point, image_pixel_size: int) -> Point:
+        return Point(
+            p.x / image_pixel_size,
+            p.y / image_pixel_size
+        )
+
+    @staticmethod
+    def parse_path(path_string: str) -> Path:
+        r = re.compile(MapDataParserDreame.PATH_REGEX)
+        matches = [m.groupdict() for m in r.finditer(path_string)]
+
+        current_path = []
+        path_points = []
+        current_position = Point(0, 0)
+        for match in matches:
+            if match["operator"] == MapDataParserDreame.PathOperators.START:
+                current_path = []
+                path_points.append(current_path)
+                current_position = Point(int(match["x"]), int(match["y"]))
+            elif match["operator"] == MapDataParserDreame.PathOperators.RELATIVE_LINE:
+                current_position = Point(current_position.x + int(match["x"]), current_position.y + int(match["y"]))
+            else:
+                _LOGGER.error(f'invalid path operator {match["operator"]}')
+            current_path.append(current_position)
+
+        path_points = [item for sublist in path_points for item in sublist]
+        return Path(None, None, None, path_points)
+
+    @staticmethod
+    def parse_areas(areas: list) -> List[Area]:
+        parsed_areas = []
+        for area in areas:
+            x_coords = sorted([area[0], area[2]])
+            y_coords = sorted([area[1], area[3]])
+            parsed_areas.append(
+                Area(
+                    x_coords[0], y_coords[0],
+                    x_coords[1], y_coords[0],
+                    x_coords[1], y_coords[1],
+                    x_coords[0], y_coords[1]
+                )
+            )
+        return parsed_areas
+
+    @staticmethod
+    def read_int_8(data: bytes, offset: int = 0):
+        return int.from_bytes(data[offset:offset + 1], byteorder='big', signed=True)
+
+    @staticmethod
+    def read_int_8_le(data: bytes, offset: int = 0):
+        return int.from_bytes(data[offset:offset + 1], byteorder='little', signed=True)
+
+    @staticmethod
+    def read_int_16(data: bytes, offset: int = 0):
+        return int.from_bytes(data[offset:offset + 2], byteorder='big', signed=True)
+
+    @staticmethod
+    def read_int_16_le(data: bytes, offset: int = 0):
+        return int.from_bytes(data[offset:offset + 2], byteorder='little', signed=True)

--- a/custom_components/xiaomi_cloud_map_extractor/dreame/vacuum.py
+++ b/custom_components/xiaomi_cloud_map_extractor/dreame/vacuum.py
@@ -1,5 +1,6 @@
+from custom_components.xiaomi_cloud_map_extractor.common.map_data import MapData
 from custom_components.xiaomi_cloud_map_extractor.common.vacuum_v2 import XiaomiCloudVacuumV2
-
+from custom_components.xiaomi_cloud_map_extractor.dreame.map_data_parser import MapDataParserDreame
 
 class DreameVacuum(XiaomiCloudVacuumV2):
 
@@ -8,3 +9,11 @@ class DreameVacuum(XiaomiCloudVacuumV2):
 
     def get_map_archive_extension(self):
         return "b64"
+
+    def decode_map(self, raw_map: bytes, colors, drawables, texts, sizes, image_config) -> MapData:
+        # with open('/config/frozen_map_data_dreame.vacuum.p2008.b64', 'rb') as f:
+        #     raw_map_file = f.read()
+        #     raw_map_string = raw_map_file.decode()
+        #     return MapDataParserDreame.decode_map(raw_map_string, colors, drawables, texts, sizes, image_config)
+        raw_map_string = raw_map.decode()
+        return MapDataParserDreame.decode_map(raw_map_string, colors, drawables, texts, sizes, image_config)


### PR DESCRIPTION
This P.R brings support for `dreame` models (#126)

The code is a transcript of https://github.com/Hypfer/Valetudo/blob/master/backend/lib/robots/dreame/DreameMapParser.js

Here are the tasks to achieve before merge :
- [ ] Parse regular map
- [ ] Parse RISM map
- [ ] Parse map additional data
- [ ] Parse map image
- [ ] Parse charger
- [ ] Parse robot position
- [ ] Parse robot path
- [ ] Parse no go areas
- [ ] Parse no mop areas
- [ ] Parse virtual walls
- [ ] Update documentation
- [ ] Test with a large set of raw maps