### PR TITLE
fix(dreame): rotate image according config

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/dreame/map_data_parser.py
+++ b/custom_components/xiaomi_cloud_map_extractor/dreame/map_data_parser.py
@@ -97,6 +97,7 @@ class MapDataParserDreame(MapDataParser):
 
             if not map_data.image.is_empty:
                 MapDataParserDreame.draw_elements(colors, drawables, sizes, map_data, image_config)
+                ImageHandlerDreame.rotate(map_data.image)
 
         return map_data
 


### PR DESCRIPTION
Here is a fix for dreame devices (#230) to consider map rotation config like :
```yaml
map_transformation:
  rotate: 270
```