### PR TITLE
Add document start to YAML files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 custom: ["buymeacoffee.com/PiotrMachowski", "paypal.me/PiMachowski"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,4 @@
+---
 name: Report an issue with Xiaomi Cloud Map Extractor
 description: Report an issue with Xiaomi Cloud Map Extractor.
 labels: bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+---
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question/open a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,4 @@
+---
 name: Request a feature in Xiaomi Cloud Map Extractor
 description: Request a feature in Xiaomi Cloud Map Extractor
 labels: enhancement

--- a/.github/ISSUE_TEMPLATE/new_platform_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_platform_request.yml
@@ -1,3 +1,4 @@
+---
 name: Request for support of a new vacuum/platform
 description: Request for support of a new vacuum/platform
 labels:

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,3 +1,4 @@
+---
 name: 'Automatically merge master -> dev'
 
 on:

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,3 +1,4 @@
+---
 name: Validate HACS
 on:
   push:

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,3 +1,4 @@
+---
 name: Validate with hassfest
 
 on:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,3 +1,4 @@
+---
 name: lint_python
 on: [pull_request, push]
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:

--- a/blueprints/automation/disable_vacuum_camera_update_when_docked.yaml
+++ b/blueprints/automation/disable_vacuum_camera_update_when_docked.yaml
@@ -1,3 +1,4 @@
+---
 blueprint:
   name: Disable vacuum camera update when docked
   description: Disable the automatic update of the vacuum camera when the robot is docked.

--- a/custom_components/xiaomi_cloud_map_extractor/services.yaml
+++ b/custom_components/xiaomi_cloud_map_extractor/services.yaml
@@ -1,3 +1,4 @@
+---
 reload:
   name: Reload
   description: Reload all entities of Xiaomi Cloud Map Extractor platform


### PR DESCRIPTION
It's a best practice to start YAML files with `---` to signal the start of document.

I added the map extractor to my code base (I don't use hacs) and _yamllint_ always complains that `services.yaml` misses a document start. I would like it to get rid of this warning. That's why I moved this change into the first commit. I would appreciate it, if you would at least merge this commit.

I also adapted the other YAML files in your project. If you want this changes too, you can merge all three commits.