### PR TITLE
Remove deprecated keys from hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,9 +1,6 @@
 {
   "name": "Xiaomi Cloud Map Extractor",
   "render_readme": true,
-  "domain": "xiaomi_cloud_map_extractor",
-  "documentation": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor",
-  "issue_tracker": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues",
   "zip_release": true,
   "filename": "xiaomi_cloud_map_extractor.zip"
 }


### PR DESCRIPTION
It's no longer supported: https://hacs.xyz/docs/publish/start/#hacsjson and therefore the build fails: https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/runs/7831231140?check_suite_focus=true