### PR TITLE
Replace deprecated constant for HA 2024.1

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/camera.py
+++ b/custom_components/xiaomi_cloud_map_extractor/camera.py
@@ -15,7 +15,7 @@ except ImportError:
     from miio import Vacuum as RoborockVacuum, DeviceException
 import PIL.Image as Image
 import voluptuous as vol
-from homeassistant.components.camera import Camera, ENTITY_ID_FORMAT, PLATFORM_SCHEMA, SUPPORT_ON_OFF
+from homeassistant.components.camera import Camera, CameraEntityFeature, ENTITY_ID_FORMAT, PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import generate_entity_id
@@ -205,8 +205,8 @@ class VacuumCamera(Camera):
         self._should_poll = False
 
     @property
-    def supported_features(self) -> int:
-        return SUPPORT_ON_OFF
+    def supported_features(self):
+        return CameraEntityFeature.ON_OFF
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:

--- a/custom_components/xiaomi_cloud_map_extractor/manifest.json
+++ b/custom_components/xiaomi_cloud_map_extractor/manifest.json
@@ -1,12 +1,13 @@
 {
   "domain": "xiaomi_cloud_map_extractor",
   "name": "Xiaomi Cloud Map Extractor",
-  "documentation": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor",
-  "issue_tracker": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues",
-  "dependencies": [],
   "codeowners": [
     "@PiotrMachowski"
   ],
+  "dependencies": [],
+  "documentation": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues",
   "requirements": [
     "pillow",
     "pybase64",
@@ -14,6 +15,5 @@
     "requests",
     "pycryptodome"
   ],
-  "version": "v2.2.0",
-  "iot_class": "cloud_polling"
+  "version": "v2.2.0"
 }


### PR DESCRIPTION
Had these in my logs:

```py
2023-12-31 14:33:19.819 WARNING (MainThread) [homeassistant.components.camera] SUPPORT_ON_OFF was used from xiaomi_cloud_map_extractor, this is a deprecated constant which will be removed in HA Core 2025.1. Use CameraEntityFeature.ON_OFF instead, please create a bug report at https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues
2023-12-31 14:33:19.823 WARNING (MainThread) [homeassistant.components.camera] SUPPORT_ON_OFF was used from xiaomi_cloud_map_extractor, this is a deprecated constant which will be removed in HA Core 2025.1. Use CameraEntityFeature.ON_OFF instead, please create a bug report at https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues
2023-12-31 14:33:24.736 WARNING (MainThread) [homeassistant.helpers.entity] Entity camera.stofzuiger (<class 'custom_components.xiaomi_cloud_map_extractor.camera.VacuumCamera'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <CameraEntityFeature.ON_OFF: 1>, please create a bug report at https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues and reference https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
```

It was a straight forward fix.... 😄 Tested locally, runs fine. `CameraEntityFeature` has been around since 2022.5, so this should be non-breaking for older HA versions.

Docs: https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/