### PR TITLE
Fix homes retrieval when there's no "share_home_list"

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/camera.py
+++ b/custom_components/xiaomi_cloud_map_extractor/camera.py
@@ -312,7 +312,12 @@ class VacuumCamera(Camera):
 
     def _handle_device(self):
         _LOGGER.debug("Retrieving device info, country: %s", self._country)
-        country, user_id, device_id, model = self._connector.get_device_details(self._vacuum.token, self._country)
+        token = self._vacuum.token
+        country, user_id, device_id, model = self._connector.get_device_details(token, self._country)
+
+        if device_id is None:
+            _LOGGER.error("Failed to find a device matching the given token: %s", token)
+
         if model is not None:
             self._country = country
             _LOGGER.debug("Retrieved device model: %s", model)

--- a/custom_components/xiaomi_cloud_map_extractor/common/xiaomi_cloud_connector.py
+++ b/custom_components/xiaomi_cloud_map_extractor/common/xiaomi_cloud_connector.py
@@ -163,10 +163,12 @@ class XiaomiCloudConnector:
         if (response := self.execute_api_call_encrypted(url, params)) is None:
             return None
 
-        if homelist := response["result"]["homelist"]:
+        result = response["result"]
+
+        if homelist := result["homelist"]:
             yield from (XiaomiHome(int(home["id"]), home["uid"]) for home in homelist)
 
-        if homelist := response["result"]["share_home_list"]:
+        if homelist := result.get("share_home_list", None):
             yield from (XiaomiHome(int(home["id"]), home["uid"]) for home in homelist)
 
     def get_devices_from_home_iter(self, country: str, home_id: int, owner_id: int):


### PR DESCRIPTION
- Ensures that the `gethome` response is processed correctly when there's no `share_home_list` attribute.
- Add an explicit error log when no device could be found using the provided token from configuration.

Relates to https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/pull/510
Probably fixes https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/issues/583

Previous outdated PRs:
- https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/pull/589
- https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/pull/590