### PR TITLE
Trigger viomi map upload before downloading the map

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_viomi.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_viomi.py
@@ -1,8 +1,21 @@
+import asyncio
+import logging
 from typing import Self
 
 from vacuum_map_parser_viomi.map_data_parser import ViomiMapDataParser
 from .base.model import VacuumConfig, VacuumApi
 from .base.vacuum_v2 import BaseXiaomiCloudVacuumV2
+
+_LOGGER = logging.getLogger(__name__)
+
+# Viomi vacuums do not keep a map in the cloud. They upload the current map only
+# when asked to via the `set_uploadmap` miio command; the uploaded map then
+# becomes available as cloud object "1". Without this request the cloud object
+# does not exist and the map download fails with "Object Not Found".
+_UPLOAD_MAP_METHOD = "set_uploadmap"
+_UPLOAD_MAP_PARAMS = [1]
+_VIOMI_MAP_NAME = "1"
+_MAP_UPLOAD_DELAY = 3
 
 
 class ViomiCloudVacuum(BaseXiaomiCloudVacuumV2):
@@ -29,3 +42,13 @@ class ViomiCloudVacuum(BaseXiaomiCloudVacuumV2):
     @property
     def map_data_parser(self: Self) -> ViomiMapDataParser:
         return self._viomi_map_data_parser
+
+    async def get_map_name(self: Self) -> str | None:
+        _LOGGER.debug("Requesting viomi map upload via cloud RPC")
+        response = await self._connector.get_other_info(
+            self._device_id, _UPLOAD_MAP_METHOD, _UPLOAD_MAP_PARAMS)
+        if response is None or response.get("code") != 0:
+            _LOGGER.warning("Viomi map upload request was not acknowledged: %s", response)
+            return None
+        await asyncio.sleep(_MAP_UPLOAD_DELAY)
+        return _VIOMI_MAP_NAME

--- a/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
@@ -714,7 +714,7 @@ class XiaomiCloudConnector:
         matching_device = filter(lambda device: device.device_id == device_id, devices)
         return next(matching_device, None)
 
-    async def get_other_info(self: Self, device_id: str, method: str, parameters: dict) -> Any:
+    async def get_other_info(self: Self, device_id: str, method: str, parameters: dict | list) -> Any:
         url = self.get_api_url() + "/v2/home/rpc/" + device_id
         params = {
             "data": json.dumps({"method": method, "params": parameters}, separators=(",", ":"))


### PR DESCRIPTION
## Problem

Viomi vacuums never produce a map. `ViomiCloudVacuum` inherits `get_map_name()`
from `BaseXiaomiCloudVacuum`, which returns `"0"`, so the download requests cloud
object `<user_id>/<device_id>/0`. For viomi devices that object does not exist —
every download fails (`FailedMapDownloadException`; FDS returns `Object Not Found`).

Root cause: unlike roborock, **viomi vacuums do not keep a map in the cloud**. They
upload the current map to Xiaomi FDS storage only when explicitly told to, via the
`set_uploadmap` miio command, and the uploaded map is stored as object **`1`** — not
`0`. The Mi Home app sends `set_uploadmap` whenever its map view is opened; the
integration never does.

## Fix

`ViomiCloudVacuum` now overrides `get_map_name()` to:

1. send `set_uploadmap` to the vacuum through the **existing cloud miio relay** —
   `XiaomiCloudConnector.get_other_info()` → `/v2/home/rpc/<device_id>` — so the
   viomi platform stays pure-cloud (no local miio connection added);
2. wait briefly for the vacuum to push the map;
3. return map name `"1"`.

If the upload request is not acknowledged it returns `None`, so the caller raises
`FailedMapDownloadException` and retries on the next cycle (rather than masking the
failure) — consistent with the other vacuum implementations.

This also widens `get_other_info()`'s `parameters` annotation from `dict` to
`dict | list`: legacy miio commands such as `set_uploadmap` take positional list
params, whereas the existing dreame caller passes a dict.

## Testing

Verified end-to-end against a live `viomi.vacuum.v8` ("Mi Robot Vacuum-Mop P", EU
server):

- `get_other_info(device_id, "set_uploadmap", [1])` → `{"code":0,"message":"ok","result":["ok"]}`
- afterwards cloud object `1` contains the map; object `0` stays absent
- the real `ViomiCloudVacuum.get_map()` then downloads (~8 KB zlib) and parses it
  into an 800×800, 5-room map

Before this change the same vacuum produced no map on v3 (or on v2.2.x).

## Notes

- The map slot (`1`) and the `set_uploadmap` parameter (`[1]`) were determined
  empirically on `viomi.vacuum.v8`; `set_uploadmap [0]` did not populate slot `0`
  on the test unit. Other viomi models would benefit from validation.
- Possible follow-up: viomi inherits the base `should_update_map` (always `True`),
  so the upload is requested every coordinator cycle even when the vacuum is idle.
  An override that checks vacuum state (as roborock does) could avoid that.
