### PR TITLE
Fix reauthentication when vacuum host changes

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/config_flow.py
+++ b/custom_components/xiaomi_cloud_map_extractor/config_flow.py
@@ -285,13 +285,16 @@ class XiaomiCloudMapExtractorFlowHandler(ConfigFlow, domain=DOMAIN):
             else:
                 unique_id = format_mac(self._cloud_vacuum.mac)
 
-                existing_entry = next(
-                    filter(
-                        lambda entry: entry.data[CONF_HOST] == host,
-                        self._async_current_entries(include_ignore=False),
-                    ),
-                    None,
-                )
+                if self.source == SOURCE_REAUTH:
+                    existing_entry = self._get_reauth_entry()
+                else:
+                    existing_entry = next(
+                        filter(
+                            lambda entry: entry.data[CONF_HOST] == host,
+                            self._async_current_entries(include_ignore=False),
+                        ),
+                        None,
+                    )
                 await self.async_set_unique_id(
                     unique_id, raise_on_progress=False
                 )
@@ -299,7 +302,7 @@ class XiaomiCloudMapExtractorFlowHandler(ConfigFlow, domain=DOMAIN):
                     self._abort_if_unique_id_configured()
                 self._connector.server = self._cloud_vacuum.server
                 await save_connector_config(self.hass, self._cloud_vacuum.mac, self._connector.to_config())
-                if existing_entry or self.source == SOURCE_REAUTH:
+                if existing_entry:
                     data = existing_entry.data.copy()
                     data[CONF_HOST] = host
                     data[CONF_TOKEN] = token
@@ -311,7 +314,11 @@ class XiaomiCloudMapExtractorFlowHandler(ConfigFlow, domain=DOMAIN):
                     data[CONF_PASSWORD] = self._password
                     data[CONF_SERVER] = self._cloud_vacuum.server
                     data[CONF_USED_MAP_API] = used_map_api
-                    result_entry = self.async_update_reload_and_abort(existing_entry, data=data)
+                    result_entry = self.async_update_reload_and_abort(
+                        existing_entry,
+                        unique_id=unique_id,
+                        data=data,
+                    )
                 else:
                     result_entry = self.async_create_entry(
                         title=self._cloud_vacuum.name,

--- a/tests/test_config_flow_reauth.py
+++ b/tests/test_config_flow_reauth.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+
+from custom_components.xiaomi_cloud_map_extractor import config_flow
+from custom_components.xiaomi_cloud_map_extractor.config_flow import (
+    XiaomiCloudMapExtractorFlowHandler,
+)
+from custom_components.xiaomi_cloud_map_extractor.const import CONF_USED_MAP_API
+from custom_components.xiaomi_cloud_map_extractor.connector.vacuums.base.model import (
+    VacuumApi,
+)
+from custom_components.xiaomi_cloud_map_extractor.connector.xiaomi_cloud.connector import (
+    XiaomiCloudDeviceInfo,
+)
+
+
+def test_reauth_uses_entry_from_flow_context_when_host_changed(monkeypatch) -> None:
+    async def run_test() -> None:
+        old_host = "0.0.0.0"
+        new_host = "192.0.2.10"
+        mac = "aa:bb:cc:dd:ee:ff"
+        existing_entry = SimpleNamespace(data={CONF_HOST: old_host})
+        connector = SimpleNamespace(
+            server=None,
+            to_config=Mock(return_value={"service_token": "token"}),
+        )
+        flow = SimpleNamespace(
+            source=SOURCE_REAUTH,
+            hass=object(),
+            _cloud_vacuum=XiaomiCloudDeviceInfo(
+                device_id="1234567890",
+                name="Test Vacuum",
+                model="xiaomi.vacuum.test",
+                token="1" * 32,
+                spec_type="urn:miot-spec-v2:device:vacuum:0000A006:test:1",
+                local_ip=new_host,
+                mac=mac,
+                server="ru",
+                home_id=1,
+                user_id=1,
+            ),
+            _connector=connector,
+            _username=None,
+            _password=None,
+            _validate_vacuum=AsyncMock(return_value=True),
+            _get_reauth_entry=Mock(return_value=existing_entry),
+            _async_current_entries=Mock(return_value=[]),
+            async_set_unique_id=AsyncMock(),
+            _abort_if_unique_id_configured=Mock(),
+            async_update_reload_and_abort=Mock(
+                return_value={"type": "abort", "reason": "reauth_successful"}
+            ),
+        )
+        save_connector_config = AsyncMock()
+        monkeypatch.setattr(config_flow, "save_connector_config", save_connector_config)
+
+        result = await XiaomiCloudMapExtractorFlowHandler.async_step_confirm_data(
+            flow,
+            {
+                CONF_HOST: new_host,
+                CONF_TOKEN: "2" * 32,
+                CONF_USED_MAP_API: VacuumApi.XIAOMI,
+            },
+        )
+
+        assert result == {"type": "abort", "reason": "reauth_successful"}
+        flow._get_reauth_entry.assert_called_once_with()
+        flow._async_current_entries.assert_not_called()
+        flow.async_update_reload_and_abort.assert_called_once()
+        (entry,) = flow.async_update_reload_and_abort.call_args.args
+        assert entry is existing_entry
+        assert (
+            flow.async_update_reload_and_abort.call_args.kwargs["unique_id"] == mac
+        )
+        assert (
+            flow.async_update_reload_and_abort.call_args.kwargs["data"][CONF_HOST]
+            == new_host
+        )
+        save_connector_config.assert_awaited_once()
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

- select the config entry being reauthenticated from the flow context instead of matching it by host
- update the entry unique ID when the cloud returns the vacuum's real MAC address
- add a regression test for reauthentication after the host changes

## Root cause

The confirmation step searched existing config entries using the newly submitted host. During reauthentication that host can differ from the stored value, especially when an entry contains a placeholder or the vacuum received a new IP address. The lookup then returned `None`, but the reauthentication branch still dereferenced `existing_entry.data`, causing an `AttributeError` that Home Assistant displayed as an unknown error.

## Impact

Reauthentication now updates the intended config entry even when its stored host no longer matches. It also replaces a placeholder or outdated unique ID with the MAC address returned by Xiaomi Cloud.

## Validation

- regression test reproduced the original `AttributeError` before the fix and passes after it
- test run against Home Assistant 2026.4.1 on Python 3.14
- `compileall` and `git diff --check`
- end-to-end reauthentication with a changed host and placeholder MAC completed successfully; the map loaded and no config-flow error remained in the logs
