### PR TITLE
Make the QR login link open a sign-in page instead of a JSON document

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
@@ -306,7 +306,26 @@ class XiaomiCloudConnector:
         qr_data = await qr_response.read()
         self._long_polling_url = json_resp["lp"]
 
-        return qr_data, json_resp["loginUrl"]
+        return qr_data, await self._browser_login_url(json_resp["loginUrl"])
+
+    async def _browser_login_url(self: Self, login_url: str) -> str:
+        """
+        Rewrites loginUrl so that a signed-out browser gets a sign-in page, by dropping the
+        _json=true flag from the serviceLogin redirect that it carries.
+        """
+        try:
+            response = await self._session_data.get(login_url, allow_redirects=False)
+            location = response.headers.get("Location")
+            if location is None:
+                return login_url
+            target = URL(location)
+            if "_json" not in target.query:
+                return login_url
+            # callback and followup are left alone - they complete the long polling
+            return str(target.with_query({k: v for k, v in target.query.items() if k != "_json"}))
+        except Exception:
+            _LOGGER.debug("Xiaomi cloud qr login - could not rewrite the login URL: %s", login_url)
+            return login_url
 
     async def login_with_qr_wait_for_completion(self: Self) -> None:
         try:


### PR DESCRIPTION
### The problem

In the QR login step, the "or use [this link] to log in" option gives the user a link that leads to a machine-readable document rather than a sign-in page, so there is no way to log in with it.

The link is `json_resp["loginUrl"]` returned unchanged. It redirects to `/pass/serviceLogin` carrying `_json=true`, and that endpoint then answers:

```
content-type: application/json;charset=UTF-8

&&&START&&&{"serviceParam":"{\"checkSafePhone\":false,\"checkSafeAddress\":false, ...
```

A browser that is *already* signed in to Xiaomi follows the redirect chain straight through and never sees this. It only bites users whose Xiaomi session has lapsed — which is precisely the set of users being asked to log in again.

### Root cause

`login_with_qr_get_code` sets `_json: "true"` when requesting the login URL, because the connector needs JSON back to parse `qs`, `callback` and `_sign`:

```python
data = {
    "_qrsize": "480",
    "qs": json_resp["qs"],
    "callback": json_resp["callback"],
    "_json": "true",          # needed for this request...
    ...
}
url = URL("https://account.xiaomi.com/longPolling/loginUrl").with_query(data)
```

Xiaomi bakes that flag into the redirect chain it builds for the ticket, so it is still there when you follow `loginUrl`. The flag is right for the connector's own requests and wrong for the URL handed to a person.

### The fix

Resolve that one redirect and drop `_json` before returning the URL. The `callback`/`followup` chain that completes the long polling is untouched. Only the response-format flag is removed. If the redirect can't be resolved for any reason, the original URL is returned, so this can never be worse than current behaviour.

### Verification

Same URL, with and without the flag, fetched from a signed-out session:

| | Content-Type | Body starts |
|---|---|---|
| With `_json=true` (current behaviour) | `application/json;charset=UTF-8` | `&&&START&&&{"serviceParam":...` |
| With `_json` stripped (this PR) | `text/html; charset=utf-8` | `<!doctype html><html lang="en"...` |

End-to-end through the patched connector against the live Xiaomi endpoints: QR image still retrieved (15047 bytes), returned link contains no `_json`, and the landing page comes back `HTTP 200 text/html`.

The resulting page was the real sign-in form and the login proceeded.

### Note

PR generated by [Claude Code](https://claude.com/claude-code)
