### PR TITLE
Fix blocking Roborock miio calls in event loop

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/connector/__init__.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 from collections.abc import Callable
@@ -83,7 +84,7 @@ class XiaomiCloudMapExtractorConnector:
         self._last_hash = None
 
     async def get_data(self: Self) -> XiaomiCloudMapExtractorData:
-        if self._should_get_map():
+        if await asyncio.to_thread(self._should_get_map):
             _LOGGER.debug("Downloading new map.")
             await self._get_map()
         else:

--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_roborock.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_roborock.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Self
 
@@ -94,7 +95,7 @@ class RoborockCloudVacuum(BaseXiaomiCloudVacuum):
         while map_name == MISSING_MAP_VALUE and remaining_attempts > 0:
             _LOGGER.debug("Retrieving map name from device, remaining_attempts: %d", remaining_attempts)
             try:
-                map_name = self._vacuum.map()[0]  # todo async
+                map_name = (await asyncio.to_thread(self._vacuum.map))[0]
                 _LOGGER.debug("Map name %s", map_name)
                 if map_name != MISSING_MAP_VALUE:
                     return map_name


### PR DESCRIPTION
An unreachable Roborock can block Home Assistant's event loop while the async map update calls synchronous python-miio methods. This delays unrelated event processing, including MQTT automations, until the network call returns.

Run the connector's `_should_get_map()` check and Roborock's `map()` call through `asyncio.to_thread()`. The status check continues to decide whether to download a map, and map retrieval retains its existing retries and exception handling. Polling intervals, miio timeouts, `_off_counter`, and map update policy are unchanged. Because the status check is shared, its worker-thread execution also applies to other vacuum implementations.

Validation:

- Eight isolated checks against the actual method bodies passed using fake devices: event-loop responsiveness during delayed status and map calls, off-counter behavior, moving-state reset, DeviceException handling, invalid-token propagation, forced refresh, disabled automatic updates, map retries, and the ten-attempt limit. Both responsiveness checks failed against the unchanged base. These checks isolate methods from Home Assistant and parser imports; they are not a full integration test.
- All 39 integration Python files passed syntax compilation; `git diff --check` passed.
- The reporter live-tested the status-check change on v3.0.0-alpha-24 in Home Assistant Container with an unreachable docked Roborock. Reported event-loop cumulative time fell from approximately 5.86 seconds over four updates to 0.00048 seconds over eight updates, even while three completed worker calls took approximately 37 seconds in total. These counts are not a controlled throughput comparison; they show slow device I/O leaving the event-loop path.
- The map-call change has local fake-device coverage but was not reached during the reporter's unreachable-vacuum profiler run.

Prepared against dev_extracted_libraries at 688fe3e (manifest v3.0.0-beta). Home Assistant, python-miio, and CI lint tools are not installed in the preparation environment, so full integration and CI validation were not run locally.
