### PR TITLE
Improve IJAI Xiaomi map retrieval

### DIFF
--- a/custom_components/xiaomi_cloud_map_extractor/__init__.py
+++ b/custom_components/xiaomi_cloud_map_extractor/__init__.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: XiaomiCloudMapExtractorC
         return async_create_clientsession(hass)
 
     connector_config = await restore_connector_config(hass, xcme_configuration.mac)
-    xcme_connector = XiaomiCloudMapExtractorConnector(session_creator, xcme_configuration, connector_config)
+    xcme_connector = XiaomiCloudMapExtractorConnector(session_creator, xcme_configuration, connector_config, hass)
     xcme_update_coordinator = XiaomiCloudMapExtractorDataUpdateCoordinator(hass, xcme_connector)
     await xcme_update_coordinator.async_config_entry_first_refresh()
     entry.runtime_data = XiaomiCloudMapExtractorRuntimeData(xcme_update_coordinator)

--- a/custom_components/xiaomi_cloud_map_extractor/connector/__init__.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/__init__.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Self, Type
 
 from aiohttp import ClientSession
+from homeassistant.core import HomeAssistant
 
 from .model import (
     XiaomiCloudMapExtractorData,
@@ -68,6 +69,7 @@ class XiaomiCloudMapExtractorConnector:
         session_creator: Callable[[], ClientSession],
         config: XiaomiCloudMapExtractorConnectorConfiguration,
         connector_config: XiaomiCloudConnectorConfig | None,
+        hass: HomeAssistant | None = None,
     ) -> None:
         self._config = config
         self._connector_config = connector_config
@@ -81,6 +83,7 @@ class XiaomiCloudMapExtractorConnector:
         self._forced_refresh = False
         self._auto_update = True
         self._last_hash = None
+        self._hass = hass
 
     async def get_data(self: Self) -> XiaomiCloudMapExtractorData:
         if self._should_get_map():
@@ -132,15 +135,35 @@ class XiaomiCloudMapExtractorConnector:
         _LOGGER.debug("Retrieving device info, server: %s", self._config.server)
         device_details = await self._cloud_connector.get_device_details(self._config.device_id, self._config.server)
 
-        if device_details is not None:
-            self._server = device_details.server
-            _LOGGER.debug("Retrieved device model: %s", device_details.model)
-            self._vacuum_connector = self._create_device(device_details)
-            _LOGGER.debug("Created device, used api: %s", self._used_api)
-            self._status = XiaomiCloudMapExtractorConnectorStatus.OK
-        else:
-            _LOGGER.error("Failed to retrieve model")
-            raise DeviceNotFoundException()
+        if device_details is None:
+            device_details = self._device_details_from_config()
+            if device_details is None:
+                _LOGGER.error("Failed to retrieve model")
+                raise DeviceNotFoundException()
+            _LOGGER.warning("Using configured Xiaomi device metadata after cloud device lookup failed")
+
+        self._server = device_details.server
+        _LOGGER.debug("Retrieved device model: %s", device_details.model)
+        self._vacuum_connector = self._create_device(device_details)
+        _LOGGER.debug("Created device, used api: %s", self._used_api)
+        self._status = XiaomiCloudMapExtractorConnectorStatus.OK
+
+    def _device_details_from_config(self: Self) -> XiaomiCloudDeviceInfo | None:
+        if not (self._config.device_id and self._config.model and self._config.mac):
+            return None
+        fallback_user_id = getattr(getattr(self._cloud_connector, "_session_data", None), "userId", 0)
+        return XiaomiCloudDeviceInfo(
+            device_id=self._config.device_id,
+            name=self._config.model,
+            model=self._config.model,
+            token=self._config.token,
+            spec_type="",
+            local_ip=self._config.host,
+            mac=self._config.mac,
+            server=self._config.server,
+            user_id=int(fallback_user_id or 0),
+            home_id=0,
+        )
 
     def _should_get_map(self: Self) -> bool:
         if self._forced_refresh:
@@ -148,6 +171,7 @@ class XiaomiCloudMapExtractorConnector:
             return True
         return (
             self._map_cache is None or
+            self._map_cache.map_data is None or
             self._vacuum_connector is None or
             (self._vacuum_connector.should_update_map and self._auto_update)
         )
@@ -204,6 +228,7 @@ class XiaomiCloudMapExtractorConnector:
             self._config.image_config,
             self._config.sizes,
             self._config.texts,
+            self._hass,
         )
         vacuum_class = AVAILABLE_VACUUM_PLATFORMS.get(self._used_api, UnsupportedCloudVacuum)
         return vacuum_class(vacuum_config)

--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/model.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from homeassistant.core import HomeAssistant
 from vacuum_map_parser_base.config.color import ColorsPalette
 from vacuum_map_parser_base.config.drawable import Drawable
 from vacuum_map_parser_base.config.image_config import ImageConfig
@@ -26,6 +27,7 @@ class VacuumConfig:
     image_config: ImageConfig
     sizes: Sizes
     texts: list[Text]
+    hass: HomeAssistant | None = None
 
 
 class VacuumApi(StrEnum):

--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/vacuum_base.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/vacuum_base.py
@@ -40,6 +40,7 @@ class BaseXiaomiCloudVacuum(ABC):
         self._image_config = vacuum_config.image_config
         self._sizes = vacuum_config.sizes
         self._texts = vacuum_config.texts
+        self._hass = vacuum_config.hass
 
     @staticmethod
     @abstractmethod

--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/vacuum_v2.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/base/vacuum_v2.py
@@ -1,8 +1,11 @@
 from abc import ABC
+import logging
 from typing import Self, Any
 
 from .vacuum_base import BaseXiaomiCloudVacuum, VacuumConfig
 from ...utils.dict_operations import path_extractor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class BaseXiaomiCloudVacuumV2(BaseXiaomiCloudVacuum, ABC):
@@ -21,6 +24,11 @@ class BaseXiaomiCloudVacuumV2(BaseXiaomiCloudVacuum, ABC):
         api_response = await self._connector.execute_api_call_encrypted(url, params)
         url = path_extractor(api_response, "result.url")
         if url is None:
+            _LOGGER.warning(
+                "Primary Xiaomi map URL response did not include result.url: code=%s message=%s",
+                path_extractor(api_response, "code"),
+                path_extractor(api_response, "message"),
+            )
             return await self.get_fallback_map_url(map_name)
         return url
 
@@ -31,7 +39,14 @@ class BaseXiaomiCloudVacuumV2(BaseXiaomiCloudVacuum, ABC):
             "data": f'{{"obj_name":"{self._user_id}/{self._device_id}/{map_name}"}}'
         }
         api_response = await self._connector.execute_api_call_encrypted(url, params)
-        return path_extractor(api_response, "result.url")
+        url = path_extractor(api_response, "result.url")
+        if url is None:
+            _LOGGER.warning(
+                "Fallback Xiaomi map URL response did not include result.url: code=%s message=%s",
+                path_extractor(api_response, "code"),
+                path_extractor(api_response, "message"),
+            )
+        return url
 
     def additional_data(self: Self) -> dict[str, Any]:
         super_data = super().additional_data()

--- a/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_ijai.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/vacuums/vacuum_ijai.py
@@ -1,5 +1,7 @@
 import logging
+import json
 from typing import Self, Any
+from homeassistant.const import Platform
 
 from miio.miot_device import MiotDevice
 from miio.exceptions import DeviceException
@@ -42,8 +44,10 @@ class IjaiCloudVacuum(BaseXiaomiCloudVacuumV2):
     @property
     def should_update_map(self: Self) -> bool:
         try:
-            status_value = self._miot_device.get_property_by(self._status_mapping.siid,
-                                                             self._status_mapping.piid)[0]["value"]
+            status_value = self.get_status_from_miot_state()
+            if status_value is None:
+                status_value = self._miot_device.get_property_by(self._status_mapping.siid,
+                                                                 self._status_mapping.piid)[0]["value"]
 
             if status_value in self._status_mapping.idle_at:
                 self._off_counter += 1
@@ -55,8 +59,19 @@ class IjaiCloudVacuum(BaseXiaomiCloudVacuumV2):
                 return True
         except DeviceException as de:
             if "token" not in repr(de):
-                return False
+                _LOGGER.debug("Local vacuum status check failed; trying cloud map update anyway.", exc_info=de)
+                return True
             raise FailedConnectionException(de)
+
+    def get_status_from_miot_state(self) -> int | None:
+        entity_id = self.get_xiaomi_miot_entity_id()
+        if self._hass is None or entity_id is None:
+            return None
+        state = self._hass.states.get(entity_id)
+        if state is None:
+            return None
+        status_value = state.attributes.get("vacuum.status")
+        return status_value if isinstance(status_value, int) else None
 
     @staticmethod
     def vacuum_platform() -> VacuumApi:
@@ -73,6 +88,128 @@ class IjaiCloudVacuum(BaseXiaomiCloudVacuumV2):
     async def get_map_url(self, map_name: str) -> str | None:
         return await self.get_fallback_map_url(map_name)
 
+    async def get_fallback_map_url(self: Self, map_name: str) -> str | None:
+        api_response = await self.request_xiaomi_miot_api(
+            "v2/home/get_interim_file_url_pro",
+            {"obj_name": f"{self._user_id}/{self._device_id}/{map_name}"}
+        )
+        if (api_response or {}).get("result", {}).get("url"):
+            return api_response["result"]["url"]
+        return await super().get_fallback_map_url(map_name)
+
+    async def get_map(self):
+        if self._wifi_info_sn is None or self._wifi_info_sn == "":
+            try:
+                self._wifi_info_sn = await self.get_cloud_wifi_info_sn()
+                if self._wifi_info_sn:
+                    _LOGGER.debug("Got wifi_sn from Xiaomi cloud")
+            except Exception:
+                _LOGGER.debug("Failed to get wifi_sn from Xiaomi cloud", exc_info=True)
+        return await super().get_map()
+
+    async def get_cloud_wifi_info_sn(self) -> str | None:
+        if (wifi_info_sn := self.get_wifi_info_sn_from_miot_state()) is not None:
+            return wifi_info_sn
+
+        response = await self.request_xiaomi_miot_api(
+            "miotspec/prop/get",
+            {
+                "params": [
+                    {"did": str(self._device_id), "siid": 1, "piid": 3},
+                    {"did": str(self._device_id), "siid": 1, "piid": 5},
+                    {"did": str(self._device_id), "siid": 7, "piid": 45},
+                ]
+            }
+        )
+        if (wifi_info_sn := self.extract_wifi_info_sn_from_items((response or {}).get("result", []))) is not None:
+            return wifi_info_sn
+
+        url = self._connector.get_api_url(self._server) + '/miotspec/prop/get'
+        params = {
+            "data": json.dumps({
+                "params": [
+                    {"did": str(self._device_id), "siid": 1, "piid": 3},
+                    {"did": str(self._device_id), "siid": 1, "piid": 5},
+                    {"did": str(self._device_id), "siid": 7, "piid": 45},
+                ]
+            }, separators=(",", ":"))
+        }
+        response = await self._connector.execute_api_call_encrypted(url, params)
+        return self.extract_wifi_info_sn_from_items((response or {}).get("result", []))
+
+    def get_wifi_info_sn_from_miot_state(self) -> str | None:
+        entity_id = self.get_xiaomi_miot_entity_id()
+        if self._hass is None or entity_id is None:
+            return None
+        state = self._hass.states.get(entity_id)
+        if state is None:
+            return None
+        value = state.attributes.get("sweep.multi_prop_vacuum")
+        return self.extract_wifi_info_sn_from_items([{"value": value}])
+
+    def extract_wifi_info_sn_from_items(self, items: list[dict[str, Any]]) -> str | None:
+        for item in items:
+            value = item.get("value")
+            if isinstance(value, str) and self.is_wifi_info_sn(value):
+                return value
+            if not isinstance(value, str):
+                continue
+            for prop in value.split(','):
+                cleaned_prop = str(prop).replace('"', '')
+                if str(self._user_id) in cleaned_prop:
+                    cleaned_prop = cleaned_prop.split(';')[0]
+                if self.is_wifi_info_sn(cleaned_prop):
+                    return cleaned_prop
+        return None
+
+    async def request_xiaomi_miot_api(self, api: str, data: dict[str, Any]) -> dict[str, Any] | None:
+        if self._hass is None:
+            return None
+        entity_id = self.get_xiaomi_miot_entity_id()
+        if entity_id is None:
+            return None
+        try:
+            response = await self._hass.services.async_call(
+                "xiaomi_miot",
+                "request_xiaomi_api",
+                {
+                    "entity_id": entity_id,
+                    "api": api,
+                    "data": data,
+                    "method": "POST",
+                    "crypt": True,
+                },
+                blocking=True,
+                return_response=True,
+            )
+        except Exception:
+            _LOGGER.debug("Xiaomi MIOT service fallback failed", exc_info=True)
+            return None
+        return response if isinstance(response, dict) else None
+
+    def get_xiaomi_miot_entity_id(self) -> str | None:
+        if self._hass is None:
+            return None
+        mac_suffix = (self._mac or "").replace(":", "").lower()[-4:]
+        model_suffix = self.model.split(".")[-1].lower()
+        candidates = []
+        for state in self._hass.states.async_all(Platform.VACUUM):
+            entity_id = state.entity_id.lower()
+            if model_suffix in entity_id and mac_suffix and mac_suffix in entity_id:
+                return state.entity_id
+            if state.attributes.get("sweep.multi_prop_vacuum") is not None:
+                candidates.append(state.entity_id)
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
+
+    def is_wifi_info_sn(self, value: str) -> bool:
+        return (
+            len(value) in self.WIFI_INFO_SN_POSSIBLE_LEN
+            and value.isalnum()
+            and value.isupper()
+        )
+
     def get_wifi_info_sn(self):
         wifi_info_sn = None
 
@@ -84,8 +221,7 @@ class IjaiCloudVacuum(BaseXiaomiCloudVacuumV2):
             data = self._miot_device.get_property_by(1, piid)
             if (
                 "value" in data[0]
-                and len(data[0]["value"]) in self.WIFI_INFO_SN_POSSIBLE_LEN
-                and data[0]["value"].isupper()
+                and self.is_wifi_info_sn(data[0]["value"])
             ):
                 wifi_info_sn = data[0]["value"]
                 break
@@ -101,16 +237,14 @@ class IjaiCloudVacuum(BaseXiaomiCloudVacuumV2):
                     cleaned_prop = cleaned_prop.split(';')[0]
 
                 if (
-                        len(cleaned_prop) in self.WIFI_INFO_SN_POSSIBLE_LEN
-                        and cleaned_prop.isalnum()
-                        and cleaned_prop.isupper()):
+                        cleaned_prop.isalnum()
+                        and self.is_wifi_info_sn(cleaned_prop)):
                     wifi_info_sn = cleaned_prop
         return wifi_info_sn
 
     def decode_and_parse(self, raw_map: bytes) -> MapData:
         GET_PROP_RETRIES = 5
         if self._wifi_info_sn is None or self._wifi_info_sn == "":
-            _LOGGER.debug(f"host={self._host}, token={self._token}")
             for _ in range(GET_PROP_RETRIES):
                 try:
                     self._wifi_info_sn = self.get_wifi_info_sn()

--- a/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/connector.py
@@ -89,8 +89,20 @@ class XiaomiCloudSessionData:
     expiration: datetime.datetime | None = None
 
     def is_authenticated(self) -> bool:
-        _LOGGER.debug("Authentication check: " + self.__repr__())
-        return self.serviceToken is not None and self.expiration > datetime.datetime.now() + datetime.timedelta(days=1)
+        _LOGGER.debug(
+            "Authentication check: serviceToken=%s ssecurity=%s userId=%s expiration=%s",
+            self.serviceToken is not None,
+            self.ssecurity is not None,
+            self.userId is not None,
+            self.expiration,
+        )
+        return (
+            self.serviceToken is not None
+            and self.ssecurity is not None
+            and self.userId is not None
+            and self.expiration is not None
+            and self.expiration > datetime.datetime.now() + datetime.timedelta(days=1)
+        )
 
     async def get(self: Self, url: StrOrURL, **kwargs: Unpack[_RequestOptions]):
         passed_headers = kwargs.pop("headers", {})
@@ -724,14 +736,14 @@ class XiaomiCloudConnector:
     async def execute_api_call_encrypted(self: Self, url: str, params: dict[str, str]) -> Any:
         headers = {
             "Accept-Encoding": "identity",
-            "x-xiaomi-protocal-flag-cli": "PROTOCAL-HTTP2",
+            "X-XIAOMI-PROTOCAL-FLAG-CLI": "PROTOCAL-HTTP2",
             "MIOT-ENCRYPT-ALGORITHM": "ENCRYPT-RC4",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
         cookies = {
             k: str(v)
             for k, v in {
                 "userId": self._session_data.userId,
-                "cUserId": self._session_data.cUserId,
                 "yetAnotherServiceToken": self._session_data.serviceToken,
                 "serviceToken": self._session_data.serviceToken,
                 "locale": self._locale,
@@ -749,7 +761,7 @@ class XiaomiCloudConnector:
 
         try:
             _LOGGER.debug("Request URL: %s", url)
-            response = await self._session_data.post(url, headers=headers, cookies=cookies, params=fields)
+            response = await self._session_data.post(url, headers=headers, cookies=cookies, data=fields)
             response_text = await response.text()
             _LOGGER.debug("API response: %s", response_text)
         except Exception as e:
@@ -760,6 +772,7 @@ class XiaomiCloudConnector:
         if response.status in [401, 403]:
             raise FailedLoginException()
         else:
+            _LOGGER.warning("Encrypted Xiaomi API request failed: status=%s", response.status)
             return None
 
     def get_api_url(self: Self, server: str | None = None) -> str:

--- a/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/utils.py
+++ b/custom_components/xiaomi_cloud_map_extractor/connector/xiaomi_cloud/utils.py
@@ -14,9 +14,8 @@ def generate_nonce(millis: int):
 
 
 def generate_agent() -> str:
-    agent_id = random_text(65, 69, 13)
-    prefix = random_text(97, 122, 18)
-    return f"{prefix}-{agent_id} APP/com.xiaomi.mihome APPV/10.5.201"
+    client_id = random_text(65, 90, 16)
+    return f"Android-7.1.1-1.0.0-ONEPLUS A3010-136-{client_id} APP/xiaomi.smarthome APPV/62830"
 
 
 def generate_device_id() -> str:

--- a/custom_components/xiaomi_cloud_map_extractor/legacy.py
+++ b/custom_components/xiaomi_cloud_map_extractor/legacy.py
@@ -44,6 +44,7 @@ from .const import (
     DOMAIN,
     NAME,
 )
+from .connector.vacuums.base.model import VacuumApi
 from .connector.xiaomi_cloud.connector import XiaomiCloudConnector, XiaomiCloudDeviceInfo
 
 
@@ -412,17 +413,22 @@ async def create_config_entry_data_from_yaml(
     except BaseException as e:
         _LOGGER.error("Failed to connect to Xiaomi Cloud", exc_info=e)
 
+    used_map_api = import_info.get(LEGACY_CONF_FORCE_API)
+    if model is not None and used_map_api is None:
+        detected_api = VacuumApi.detect(model)
+        used_map_api = detected_api.value if detected_api is not None else None
+
     data = {
         CONF_HOST: import_info[CONF_HOST],
         CONF_TOKEN: import_info[CONF_TOKEN],
         CONF_DEVICE_ID: device_id,
         CONF_MODEL: model,
         CONF_MAC: mac,
-        CONF_NAME: name,
+        CONF_NAME: import_info.get(CONF_NAME) or name,
         CONF_USERNAME: import_info[CONF_USERNAME],
         CONF_PASSWORD: import_info[CONF_PASSWORD],
         CONF_SERVER: server,
-        CONF_USED_MAP_API: import_info.get(LEGACY_CONF_FORCE_API, None),
+        CONF_USED_MAP_API: used_map_api,
     }
     options = {
         CONF_IMAGE_CONFIG: {

--- a/custom_components/xiaomi_cloud_map_extractor/store.py
+++ b/custom_components/xiaomi_cloud_map_extractor/store.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
@@ -19,11 +20,13 @@ async def save_connector_config(
 async def restore_connector_config(
     hass: HomeAssistant, mac: str
 ) -> XiaomiCloudConnectorConfig | None:
+    connector_config = await _restore_from_xiaomi_miot(hass)
+    if connector_config is not None:
+        return XiaomiCloudConnectorConfig.from_dict(connector_config)
+
     store = _create_store(hass, mac)
     stored_data = await store.async_load()
-    if (
-        stored_data is None or (connector_config := stored_data.get("connector_config", None)) is None
-    ):
+    if stored_data is None or (connector_config := stored_data.get("connector_config", None)) is None:
         return None
     return XiaomiCloudConnectorConfig.from_dict(connector_config)
 
@@ -31,3 +34,29 @@ async def restore_connector_config(
 def _create_store(hass: HomeAssistant, mac: str) -> Store:
     store = Store(hass, STORAGE_VERSION, f"{DOMAIN}_{format_mac(mac)}")
     return store
+
+
+async def _restore_from_xiaomi_miot(hass: HomeAssistant) -> dict | None:
+    for entry in hass.config_entries.async_entries("xiaomi_miot"):
+        data = entry.data or {}
+        user_id = str(data.get("user_id") or "")
+        server = data.get("server_country") or "cn"
+        auth_store = Store(hass, 1, f"xiaomi_miot/auth-{user_id}-{server}.json")
+        auth_data = (await auth_store.async_load() or {}).get("data", {})
+        service_token = auth_data.get("service_token") or data.get("service_token")
+        ssecurity = auth_data.get("ssecurity") or data.get("ssecurity")
+        user_id = str(auth_data.get("user_id") or user_id)
+        if not (service_token and ssecurity and user_id):
+            continue
+        return {
+            "username": auth_data.get("username") or data.get("username"),
+            "password": data.get("password"),
+            "server": auth_data.get("server_country") or server,
+            "user_id": user_id,
+            "c_user_id": user_id,
+            "service_token": service_token,
+            "expiration": (datetime.now() + timedelta(days=30)).isoformat(),
+            "ssecurity": ssecurity,
+            "device_id": auth_data.get("device_id") or data.get("device_id"),
+        }
+    return None


### PR DESCRIPTION

<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/02bbcb1a-3b9e-4039-9e4b-4c91367b86aa" />


## Summary

- Add IJAI/Xiaomi MIOT fallbacks for map URL retrieval and wifi serial discovery
- Fall back to configured device metadata when cloud device lookup does not return details
- Adjust encrypted Xiaomi API requests to send RC4 fields as form data and avoid logging sensitive auth data
- Preserve existing direct Xiaomi API fallbacks when Xiaomi MIOT data is unavailable

## Tested

- Verified on a Xiaomi S20 (`xiaomi.vacuum.d106gl`) setup where the vacuum map now loads successfully
- Ran `python3.12 -m compileall -q custom_components/xiaomi_cloud_map_extractor`
- Ran `git diff --check`
